### PR TITLE
Various Router Improvements

### DIFF
--- a/ReSwiftRouter.xcodeproj/xcshareddata/xcschemes/ReSwiftRouter-iOS.xcscheme
+++ b/ReSwiftRouter.xcodeproj/xcshareddata/xcschemes/ReSwiftRouter-iOS.xcscheme
@@ -26,7 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/ReSwiftRouter/NavigationActions.swift
+++ b/ReSwiftRouter/NavigationActions.swift
@@ -30,3 +30,13 @@ public struct SetRouteAction: StandardActionConvertible {
     }
     
 }
+
+public struct SetRouteSpecificData: Action {
+    let route: Route
+    let data: Any
+
+    public init(route: Route, data: Any) {
+        self.route = route
+        self.data = data
+    }
+}

--- a/ReSwiftRouter/NavigationActions.swift
+++ b/ReSwiftRouter/NavigationActions.swift
@@ -15,18 +15,25 @@ public let typeMap: [String: StandardActionConvertible.Type] =
 public struct SetRouteAction: StandardActionConvertible {
 
     let route: Route
+    let animated: Bool
     public static let type = "RE_SWIFT_ROUTER_SET_ROUTE"
 
-    public init (_ route: Route) {
+    public init (_ route: Route, animated: Bool = true) {
         self.route = route
+        self.animated = animated
     }
 
     public init(_ action: StandardAction) {
         self.route = action.payload!["route"] as! Route
+        self.animated = action.payload!["animated"] as! Bool
     }
 
     public func toStandardAction() -> StandardAction {
-        return StandardAction(type: SetRouteAction.type, payload: ["route": route], isTypedAction: true)
+        return StandardAction(
+            type: SetRouteAction.type,
+            payload: ["route": route, "animated": animated],
+            isTypedAction: true
+        )
     }
     
 }

--- a/ReSwiftRouter/NavigationReducer.swift
+++ b/ReSwiftRouter/NavigationReducer.swift
@@ -22,6 +22,8 @@ public struct NavigationReducer {
         switch action {
         case let action as SetRouteAction:
             return setRoute(state, route: action.route)
+        case let action as SetRouteSpecificData:
+            return setRouteSpecificData(state, route: action.route, data: action.data)
         default:
             break
         }
@@ -33,6 +35,17 @@ public struct NavigationReducer {
         state.route = route
 
         return state
+    }
+
+    static func setRouteSpecificData(
+        var state: NavigationState,
+        route: Route,
+        data: Any) -> NavigationState{
+            let routeHash = RouteHash(route: route)
+
+            state.routeSpecificState[routeHash] = data
+
+            return state
     }
 
 }

--- a/ReSwiftRouter/NavigationReducer.swift
+++ b/ReSwiftRouter/NavigationReducer.swift
@@ -21,7 +21,7 @@ public struct NavigationReducer {
 
         switch action {
         case let action as SetRouteAction:
-            return setRoute(state, route: action.route)
+            return setRoute(state, setRouteAction: action)
         case let action as SetRouteSpecificData:
             return setRouteSpecificData(state, route: action.route, data: action.data)
         default:
@@ -31,8 +31,9 @@ public struct NavigationReducer {
         return state
     }
 
-    static func setRoute(var state: NavigationState, route: Route) -> NavigationState {
-        state.route = route
+    static func setRoute(var state: NavigationState, setRouteAction: SetRouteAction) -> NavigationState {
+        state.route = setRouteAction.route
+        state.changeRouteAnimated = setRouteAction.animated
 
         return state
     }

--- a/ReSwiftRouter/NavigationState.swift
+++ b/ReSwiftRouter/NavigationState.swift
@@ -11,9 +11,35 @@ import ReSwift
 public typealias RouteElementIdentifier = String
 public typealias Route = [RouteElementIdentifier]
 
+public struct RouteHash: Hashable {
+    let routeHash: String
+
+    init(route: Route) {
+        self.routeHash = route.joinWithSeparator("/")
+    }
+
+    public var hashValue: Int { return self.routeHash.hashValue }
+}
+
+public func == (lhs: RouteHash, rhs: RouteHash) -> Bool {
+    return lhs.routeHash == rhs.routeHash
+}
+
 public struct NavigationState {
     public init() {}
 
     public var route: Route = []
-    public var subRouteState: [StateType] = []
+    public var routeSpecificState: [RouteHash: Any] = [:]
+}
+
+extension NavigationState {
+    public func getRouteSpecificState<T>(route: Route) -> T? {
+        let hash = RouteHash(route: route)
+
+        return self.routeSpecificState[hash] as? T
+    }
+}
+
+public protocol HasNavigationState {
+    var navigationState: NavigationState { get set }
 }

--- a/ReSwiftRouter/NavigationState.swift
+++ b/ReSwiftRouter/NavigationState.swift
@@ -30,6 +30,7 @@ public struct NavigationState {
 
     public var route: Route = []
     public var routeSpecificState: [RouteHash: Any] = [:]
+    var changeRouteAnimated: Bool = true
 }
 
 extension NavigationState {

--- a/ReSwiftRouter/Routable.swift
+++ b/ReSwiftRouter/Routable.swift
@@ -10,31 +10,46 @@ public typealias RoutingCompletionHandler = () -> Void
 
 public protocol Routable {
 
-    func changeRouteSegment(from: RouteElementIdentifier,
-        to: RouteElementIdentifier,
+    func pushRouteSegment(
+        routeElementIdentifier: RouteElementIdentifier,
+        animated: Bool,
         completionHandler: RoutingCompletionHandler) -> Routable
 
-    func pushRouteSegment(routeElementIdentifier: RouteElementIdentifier,
-        completionHandler: RoutingCompletionHandler) -> Routable
-
-    func popRouteSegment(routeElementIdentifier: RouteElementIdentifier,
+    func popRouteSegment(
+        routeElementIdentifier: RouteElementIdentifier,
+        animated: Bool,
         completionHandler: RoutingCompletionHandler)
+
+    func changeRouteSegment(
+        from: RouteElementIdentifier,
+        to: RouteElementIdentifier,
+        animated: Bool,
+        completionHandler: RoutingCompletionHandler) -> Routable
 
 }
 
 extension Routable {
-    public func changeRouteSegment(from: RouteElementIdentifier,
-        to: RouteElementIdentifier, completionHandler: RoutingCompletionHandler) -> Routable {
+
+    public func pushRouteSegment(
+        routeElementIdentifier: RouteElementIdentifier,
+        animated: Bool,
+        completionHandler: RoutingCompletionHandler) -> Routable {
             fatalError("This routable cannot change segments. You have not implemented it.")
     }
 
-    public func popRouteSegment(routeElementIdentifier: RouteElementIdentifier,
+    public func popRouteSegment(
+        routeElementIdentifier: RouteElementIdentifier,
+        animated: Bool,
         completionHandler: RoutingCompletionHandler) {
             fatalError("This routable cannot change segments. You have not implemented it.")
     }
 
-    public func pushRouteSegment(routeElementIdentifier: RouteElementIdentifier,
+    public func changeRouteSegment(
+        from: RouteElementIdentifier,
+        to: RouteElementIdentifier,
+        animated: Bool,
         completionHandler: RoutingCompletionHandler) -> Routable {
             fatalError("This routable cannot change segments. You have not implemented it.")
     }
+
 }

--- a/ReSwiftRouter/Router.swift
+++ b/ReSwiftRouter/Router.swift
@@ -77,9 +77,12 @@ public class Router<State: StateType>: StoreSubscriber {
                 let result = dispatch_semaphore_wait(semaphore, waitUntil)
 
                 if result != 0 {
-                    assertionFailure("[SwiftFlowRouter]: Router is stuck waiting for a" +
-                        " completion handler to be called. Ensure that you have called the " +
+                    print("[SwiftFlowRouter]: Router is stuck waiting for a" +
+                        " completion handler to be called. Ensure that you have called the" +
                         " completion handler in each Routable element.")
+                    print("Set a symbolic breakpoint for the `ReSwiftRouterStuck` symbol in order" +
+                        " to halt the program when this happens")
+                    ReSwiftRouterStuck()
                 }
             }
 
@@ -193,6 +196,8 @@ public class Router<State: StateType>: StoreSubscriber {
     }
 
 }
+
+func ReSwiftRouterStuck() {}
 
 enum RoutingActions {
     case Push(responsibleRoutableIndex: Int, segmentToBePushed: RouteElementIdentifier)

--- a/ReSwiftRouter/Router.swift
+++ b/ReSwiftRouter/Router.swift
@@ -44,8 +44,10 @@ public class Router<State: StateType>: StoreSubscriber {
                 case let .Pop(responsibleRoutableIndex, segmentToBePopped):
                     dispatch_async(dispatch_get_main_queue()) {
                         self.routables[responsibleRoutableIndex]
-                            .popRouteSegment(segmentToBePopped) {
-                            dispatch_semaphore_signal(semaphore)
+                            .popRouteSegment(
+                                segmentToBePopped,
+                                animated: state.changeRouteAnimated) {
+                                    dispatch_semaphore_signal(semaphore)
                         }
 
                         self.routables.removeAtIndex(responsibleRoutableIndex + 1)
@@ -55,8 +57,10 @@ public class Router<State: StateType>: StoreSubscriber {
                     dispatch_async(dispatch_get_main_queue()) {
                         self.routables[responsibleRoutableIndex + 1] =
                             self.routables[responsibleRoutableIndex]
-                                .changeRouteSegment(segmentToBeReplaced,
-                                    to: newSegment) {
+                                .changeRouteSegment(
+                                    segmentToBeReplaced,
+                                    to: newSegment,
+                                    animated: state.changeRouteAnimated) {
                                         dispatch_semaphore_signal(semaphore)
                         }
                     }
@@ -65,8 +69,10 @@ public class Router<State: StateType>: StoreSubscriber {
                     dispatch_async(dispatch_get_main_queue()) {
                         self.routables.append(
                             self.routables[responsibleRoutableIndex]
-                                .pushRouteSegment(segmentToBePushed) {
-                                    dispatch_semaphore_signal(semaphore)
+                                .pushRouteSegment(
+                                    segmentToBePushed,
+                                    animated: state.changeRouteAnimated) {
+                                        dispatch_semaphore_signal(semaphore)
                             }
                         )
                     }

--- a/ReSwiftRouterTests/ReSwiftRouterIntegrationTests.swift
+++ b/ReSwiftRouterTests/ReSwiftRouterIntegrationTests.swift
@@ -178,6 +178,35 @@ class SwiftFlowRouterIntegrationTests: QuickSpec {
             }
 
         }
+
+
+        describe("route specific data") {
+
+            var store: Store<FakeAppState>!
+
+            beforeEach {
+                store = Store(reducer: AppReducer(), state: nil)
+            }
+
+            context("when setting route specific data") {
+
+                beforeEach {
+                    store.dispatch(SetRouteSpecificData(route: ["part1", "part2"], data: "UserID_10"))
+                }
+
+                it("allows accessing the data when providing the expected type") {
+                    let data: String? = store.state.navigationState.getRouteSpecificState(
+                        ["part1", "part2"]
+                    )
+
+                    expect(data).toEventually(equal("UserID_10"))
+                }
+                
+            }
+            
+        }
+
+
     }
     
 }

--- a/ReSwiftRouterTests/ReSwiftRouterIntegrationTests.swift
+++ b/ReSwiftRouterTests/ReSwiftRouterIntegrationTests.swift
@@ -125,7 +125,6 @@ class SwiftFlowRouterIntegrationTests: QuickSpec {
 
                 it("calls push on the root for a route with two elements") {
                     store.dispatch(
-
                         SetRouteAction(
                             ["TabBarViewController", "SecondViewController"]
                         )

--- a/ReSwiftRouterTests/ReSwiftRouterIntegrationTests.swift
+++ b/ReSwiftRouterTests/ReSwiftRouterIntegrationTests.swift
@@ -11,25 +11,47 @@ import Nimble
 import ReSwift
 @testable import ReSwiftRouter
 
-class FakeRoutable: Routable {
+class MockRoutable: Routable {
 
-
-    func pushRouteSegment(routeSegment: RouteElementIdentifier,
-        completionHandler: RoutingCompletionHandler) -> Routable {
-            completionHandler()
-            return FakeRoutable()
-    }
-
-    func popRouteSegment(routeSegment: RouteElementIdentifier,
-        completionHandler: RoutingCompletionHandler) {
-            completionHandler()
-    }
-
-    func changeRouteSegment(from: RouteElementIdentifier,
+    var callsToPushRouteSegment: [(routeElement: RouteElementIdentifier, animated: Bool)] = []
+    var callsToPopRouteSegment: [(routeElement: RouteElementIdentifier, animated: Bool)] = []
+    var callsToChangeRouteSegment: [(
+        from: RouteElementIdentifier,
         to: RouteElementIdentifier,
+        animated: Bool
+    )] = []
+
+    func pushRouteSegment(
+        routeElementIdentifier: RouteElementIdentifier,
+        animated: Bool,
+        completionHandler: RoutingCompletionHandler) -> Routable {
+            callsToPushRouteSegment.append(
+                (routeElement: routeElementIdentifier, animated: animated)
+            )
+            completionHandler()
+            return MockRoutable()
+    }
+
+    func popRouteSegment(
+        routeElementIdentifier: RouteElementIdentifier,
+        animated: Bool,
+        completionHandler: RoutingCompletionHandler) {
+            callsToPopRouteSegment.append(
+                (routeElement: routeElementIdentifier, animated: animated)
+            )
+            completionHandler()
+    }
+
+    func changeRouteSegment(
+        from: RouteElementIdentifier,
+        to: RouteElementIdentifier,
+        animated: Bool,
         completionHandler: RoutingCompletionHandler) -> Routable {
             completionHandler()
-            return FakeRoutable()
+
+            callsToChangeRouteSegment.append((from: from, to: to, animated: animated))
+
+            return MockRoutable()
     }
 
 }
@@ -74,7 +96,7 @@ class SwiftFlowRouterIntegrationTests: QuickSpec {
                         func pushRouteSegment(routeElementIdentifier: RouteElementIdentifier,
                             completionHandler: RoutingCompletionHandler) -> Routable {
                                 called = true
-                                return FakeRoutable()
+                                return MockRoutable()
                         }
                     }
 
@@ -100,12 +122,14 @@ class SwiftFlowRouterIntegrationTests: QuickSpec {
                             self.calledWithIdentifier = calledWithIdentifier
                         }
 
-                        func pushRouteSegment(routeSegment: RouteElementIdentifier,
+                        func pushRouteSegment(
+                            routeSegment: RouteElementIdentifier,
+                            animated: Bool,
                             completionHandler: RoutingCompletionHandler) -> Routable {
                                 calledWithIdentifier(routeSegment)
 
                                 completionHandler()
-                                return FakeRoutable()
+                                return MockRoutable()
                         }
 
                     }
@@ -137,12 +161,14 @@ class SwiftFlowRouterIntegrationTests: QuickSpec {
                             self.calledWithIdentifier = calledWithIdentifier
                         }
 
-                        func pushRouteSegment(routeSegment: RouteElementIdentifier,
+                        func pushRouteSegment(
+                            routeSegment: RouteElementIdentifier,
+                            animated: Bool,
                             completionHandler: RoutingCompletionHandler) -> Routable {
                                 calledWithIdentifier(routeSegment)
 
                                 completionHandler()
-                                return FakeRoutable()
+                                return MockRoutable()
                         }
                     }
 
@@ -160,7 +186,9 @@ class SwiftFlowRouterIntegrationTests: QuickSpec {
                                 self.injectedRoutable = injectedRoutable
                             }
 
-                            func pushRouteSegment(routeElementIdentifier: RouteElementIdentifier,
+                            func pushRouteSegment(
+                                routeElementIdentifier: RouteElementIdentifier,
+                                animated: Bool,
                                 completionHandler: RoutingCompletionHandler) -> Routable {
                                     completionHandler()
                                     return injectedRoutable
@@ -203,6 +231,54 @@ class SwiftFlowRouterIntegrationTests: QuickSpec {
                 
             }
             
+        }
+
+        describe("configuring animated/unanimated navigation") {
+
+            var store: Store<FakeAppState>!
+            var mockRoutable: MockRoutable!
+            var router: Router<FakeAppState>!
+
+            beforeEach {
+                store = Store(reducer: AppReducer(), state: nil)
+                mockRoutable = MockRoutable()
+                router = Router(store: store, rootRoutable: mockRoutable) { state in
+                    state.navigationState
+                }
+
+                // silence router not read warning, need to keep router alive via reference
+                _ = router
+            }
+
+            context("when dispatching an animated route change") {
+                beforeEach {
+                    store.dispatch(SetRouteAction(["someRoute"], animated: true))
+                }
+
+                it("calls routables asking for an animated presentation") {
+                    expect(mockRoutable.callsToPushRouteSegment.last?.animated).toEventually(beTrue())
+                }
+            }
+
+            context("when dispatching an unanimated route change") {
+                beforeEach {
+                    store.dispatch(SetRouteAction(["someRoute"], animated: false))
+                }
+
+                it("calls routables asking for an animated presentation") {
+                    expect(mockRoutable.callsToPushRouteSegment.last?.animated).toEventually(beFalse())
+                }
+            }
+
+            context("when dispatching a default route change") {
+                beforeEach {
+                    store.dispatch(SetRouteAction(["someRoute"]))
+                }
+
+                it("calls routables asking for an animated presentation") {
+                    expect(mockRoutable.callsToPushRouteSegment.last?.animated).toEventually(beTrue())
+                }
+            }
         }
 
 

--- a/ReSwiftRouterTests/ReSwiftRouterTestsUnitTests.swift
+++ b/ReSwiftRouterTests/ReSwiftRouterTestsUnitTests.swift
@@ -234,6 +234,7 @@ class ReSwiftRouterUnitTests: QuickSpec {
             }
 
         }
+
     }
 
 }


### PR DESCRIPTION
Tackles issues brought up about ReSwiftRouter.

- There is now a dedicated way to set stored data for a specific route (equivalent of calling URL with query parameter, or something similar) as requested in #3 
- Router no longer asserts when it is stuck, instead it prints a warning and offers a hook for symbolic breakpoint. This was addressed in #12 
- Provide the ability to switch a route animated/unanimated as requested in #4 