### PR TITLE
Variadic parameter route action

### DIFF
--- a/ReSwiftRouter/NavigationActions.swift
+++ b/ReSwiftRouter/NavigationActions.swift
@@ -23,8 +23,8 @@ public struct SetRouteAction: StandardActionConvertible {
         self.animated = animated
     }
     
-    public init(route: RouteElementIdentifier...) {
-        self.init(route)
+    public init(route: RouteElementIdentifier..., animated: Bool = true) {
+        self.init(route, animated: animated)
     }
 
     public init(_ action: StandardAction) {
@@ -43,8 +43,8 @@ public struct SetRouteAction: StandardActionConvertible {
 }
 
 public extension Store {
-    public func dispatchRoute(route: RouteElementIdentifier...) {
-        dispatch(SetRouteAction(route))
+    public func dispatchRoute(route: RouteElementIdentifier..., animated: Bool = true) {
+        dispatch(SetRouteAction(route, animated: animated))
     }
 }
 

--- a/ReSwiftRouter/NavigationActions.swift
+++ b/ReSwiftRouter/NavigationActions.swift
@@ -22,6 +22,10 @@ public struct SetRouteAction: StandardActionConvertible {
         self.route = route
         self.animated = animated
     }
+    
+    public init(route: RouteElementIdentifier...) {
+        self.init(route)
+    }
 
     public init(_ action: StandardAction) {
         self.route = action.payload!["route"] as! Route
@@ -36,6 +40,12 @@ public struct SetRouteAction: StandardActionConvertible {
         )
     }
     
+}
+
+public extension Store {
+    public func dispatchRoute(route: RouteElementIdentifier...) {
+        dispatch(SetRouteAction(route))
+    }
 }
 
 public struct SetRouteSpecificData: Action {


### PR DESCRIPTION
1. add variadic parameter initialiser to `SetRouteAction`
2. extend `ReSwift.Store` with an analogous `dispatchRoute` convenience method

So that this:

```swift
store.dispatch(SetRouteAction([mainViewRoute, bookmarkRoute]))
```

… can be written as:

```swift
store.dispatch(SetRouteAction(mainViewRoute, bookmarkRoute))
```

… or even:

```swift
store.dispatchRoute(mainViewRoute, bookmarkRoute)
```

(This is my first ever pull request. Please let me know if I am doing it all wrong. Many thanks!)