### PR TITLE
Release 0.3.1

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,11 @@
+#0.3.1
+
+*Released: 07/16/2016*
+
+**Fixes:**
+ 
+- Expose `RouteHash` initializer publicly - @Ben-G
+
 #0.3.0
 
 *Released: 06/28/2016*

--- a/ReSwiftRouter.podspec
+++ b/ReSwiftRouter.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "ReSwiftRouter"
-  s.version          = "0.3.0"
+  s.version          = "0.3.1"
   s.summary          = "Declarative Routing for ReSwift"
   s.description      = <<-DESC
                           A declarative router for ReSwift. Allows developers to declare routes in a similar manner as

--- a/ReSwiftRouter.xcodeproj/project.pbxproj
+++ b/ReSwiftRouter.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		254B3BAD1D3AD6DD00B1E4F0 /* RouteHashSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 254B3BAC1D3AD6DD00B1E4F0 /* RouteHashSpec.swift */; };
+		254B3BAE1D3AD6DD00B1E4F0 /* RouteHashSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 254B3BAC1D3AD6DD00B1E4F0 /* RouteHashSpec.swift */; };
+		254B3BAF1D3AD6DD00B1E4F0 /* RouteHashSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 254B3BAC1D3AD6DD00B1E4F0 /* RouteHashSpec.swift */; };
 		25C0A9CD1C50AF6400139FA7 /* NavigationActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25C0A9C61C50AF6400139FA7 /* NavigationActions.swift */; };
 		25C0A9CE1C50AF6400139FA7 /* NavigationReducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25C0A9C71C50AF6400139FA7 /* NavigationReducer.swift */; };
 		25C0A9CF1C50AF6400139FA7 /* NavigationState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25C0A9C81C50AF6400139FA7 /* NavigationState.swift */; };
@@ -244,6 +247,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		254B3BAC1D3AD6DD00B1E4F0 /* RouteHashSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RouteHashSpec.swift; path = ReSwiftRouterTests/RouteHashSpec.swift; sourceTree = SOURCE_ROOT; };
 		25C0A9C51C50AF6400139FA7 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = ReSwiftRouter/Info.plist; sourceTree = SOURCE_ROOT; };
 		25C0A9C61C50AF6400139FA7 /* NavigationActions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NavigationActions.swift; path = ReSwiftRouter/NavigationActions.swift; sourceTree = SOURCE_ROOT; };
 		25C0A9C71C50AF6400139FA7 /* NavigationReducer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NavigationReducer.swift; path = ReSwiftRouter/NavigationReducer.swift; sourceTree = SOURCE_ROOT; };
@@ -385,6 +389,7 @@
 				25C0A9D31C50AF8B00139FA7 /* Info.plist */,
 				25C0A9D41C50AF8B00139FA7 /* ReSwiftRouterIntegrationTests.swift */,
 				25C0A9D51C50AF8B00139FA7 /* ReSwiftRouterTestsUnitTests.swift */,
+				254B3BAC1D3AD6DD00B1E4F0 /* RouteHashSpec.swift */,
 				625E67001C2001F60027C288 /* Frameworks */,
 			);
 			name = ReSwiftRouterTests;
@@ -917,6 +922,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				254B3BAE1D3AD6DD00B1E4F0 /* RouteHashSpec.swift in Sources */,
 				6209C07E1C542838004E6B66 /* ReSwiftRouterIntegrationTests.swift in Sources */,
 				6209C07F1C54283A004E6B66 /* ReSwiftRouterTestsUnitTests.swift in Sources */,
 			);
@@ -938,6 +944,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				254B3BAF1D3AD6DD00B1E4F0 /* RouteHashSpec.swift in Sources */,
 				6209C0AC1C542BCA004E6B66 /* ReSwiftRouterIntegrationTests.swift in Sources */,
 				6209C0AB1C542BC7004E6B66 /* ReSwiftRouterTestsUnitTests.swift in Sources */,
 			);
@@ -959,6 +966,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				254B3BAD1D3AD6DD00B1E4F0 /* RouteHashSpec.swift in Sources */,
 				25C0A9D91C50AF8D00139FA7 /* ReSwiftRouterIntegrationTests.swift in Sources */,
 				25C0A9DA1C50AF8F00139FA7 /* ReSwiftRouterTestsUnitTests.swift in Sources */,
 			);

--- a/ReSwiftRouter/Info.plist
+++ b/ReSwiftRouter/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.3.0</string>
+	<string>0.3.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/ReSwiftRouter/NavigationState.swift
+++ b/ReSwiftRouter/NavigationState.swift
@@ -11,10 +11,12 @@ import ReSwift
 public typealias RouteElementIdentifier = String
 public typealias Route = [RouteElementIdentifier]
 
+/// A `Hashable` and `Equatable` presentation of a route.
+/// Can be used to check two routes for equality.
 public struct RouteHash: Hashable {
     let routeHash: String
 
-    init(route: Route) {
+    public init(route: Route) {
         self.routeHash = route.joinWithSeparator("/")
     }
 

--- a/ReSwiftRouterTests/Info.plist
+++ b/ReSwiftRouterTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.3.0</string>
+	<string>0.3.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/ReSwiftRouterTests/RouteHashSpec.swift
+++ b/ReSwiftRouterTests/RouteHashSpec.swift
@@ -1,0 +1,51 @@
+//
+//  RouteHashTests.swift
+//  ReSwiftRouter
+//
+//  Created by Benji Encz on 7/16/16.
+//  Copyright © 2016 Benjamin Encz. All rights reserved.
+//
+
+import ReSwiftRouter
+import Quick
+import Nimble
+
+class RouteHashTests: QuickSpec {
+
+    override func spec() {
+
+        describe("when two route hashs are initialized with the same elements") {
+
+            var routeHash1: RouteHash!
+            var routeHash2: RouteHash!
+
+            beforeEach {
+                routeHash1 = RouteHash(route: ["part1", "part2"])
+                routeHash2 = RouteHash(route: ["part1", "part2"])
+            }
+
+            it("both hashs are considered equal") {
+                expect(routeHash1).to(equal(routeHash2))
+            }
+
+        }
+
+        describe("when two route hashs are initialized with different elements") {
+
+            var routeHash1: RouteHash!
+            var routeHash2: RouteHash!
+
+            beforeEach {
+                routeHash1 = RouteHash(route: ["part1", "part2"])
+                routeHash2 = RouteHash(route: ["part3", "part4"])
+            }
+
+            it("both hashs are considered equal") {
+                expect(routeHash1).toNot(equal(routeHash2))
+            }
+
+        }
+
+    }
+
+}


### PR DESCRIPTION
Make initializer for `RouteHash` publicly available. Future releases should add a `Route` type that is `Equatable` instead of using a separate type.