### PR TITLE
SWIFT_VERSION error on carthage update

### DIFF
--- a/ReSwiftRouter.xcodeproj/project.pbxproj
+++ b/ReSwiftRouter.xcodeproj/project.pbxproj
@@ -440,7 +440,7 @@
 				62AC57BB1CA3A04D0007C9FA /* ReSwift.framework */,
 				62AC57BD1CA3A04D0007C9FA /* ReSwift-iOSTests.xctest */,
 				62AC57BF1CA3A04D0007C9FA /* ReSwift.framework */,
-				62AC57C11CA3A04D0007C9FA /* ReSwift-OSXTests.xctest */,
+				62AC57C11CA3A04D0007C9FA /* ReSwift-macOSTests.xctest */,
 				62AC57C31CA3A04D0007C9FA /* ReSwift.framework */,
 				62AC57C51CA3A04D0007C9FA /* ReSwift-tvOSTests.xctest */,
 				62AC57C71CA3A04D0007C9FA /* ReSwift.framework */,
@@ -812,7 +812,7 @@
 			remoteRef = 62AC57BE1CA3A04D0007C9FA /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		62AC57C11CA3A04D0007C9FA /* ReSwift-OSXTests.xctest */ = {
+		62AC57C11CA3A04D0007C9FA /* ReSwift-macOSTests.xctest */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.cfbundle;
 			path = "ReSwift-macOSTests.xctest";
@@ -1010,6 +1010,7 @@
 				PRODUCT_NAME = ReSwiftRouter;
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = 4;
 				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};
@@ -1030,6 +1031,7 @@
 				PRODUCT_NAME = ReSwiftRouter;
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = 4;
 				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};
@@ -1049,6 +1051,7 @@
 				PRODUCT_NAME = ReSwiftRouter;
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
@@ -1068,6 +1071,7 @@
 				PRODUCT_NAME = ReSwiftRouter;
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
@@ -1115,6 +1119,7 @@
 				PRODUCT_NAME = ReSwiftRouter;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -1136,6 +1141,7 @@
 				PRODUCT_NAME = ReSwiftRouter;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
fix for error when using carthage update on branch "swift-3"

=== BUILD TARGET ReSwiftRouter-OSX OF PROJECT ReSwiftRouter WITH CONFIGURATION Release ===

Check dependencies
“Use Legacy Swift Language Version” (SWIFT_VERSION) is required to be configured correctly for targets which use Swift. Use the [Edit > Convert > To Current Swift Syntax…] menu to choose a Swift version or use the Build Settings editor to configure the build setting directly.

** BUILD FAILED **