### PR TITLE
[wip] Allow safe handling of Routable calls

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "ReSwift/ReSwift" ~> 3.0.0
+github "ReSwift/ReSwift" "master"

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "ReSwift/ReSwift" "master"
+github "ReSwift/ReSwift" "6161a8fc55d94c30c5c854c4b22a185074b1c75f"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
 github "Quick/Nimble" "v5.1.1"
 github "Quick/Quick" "v1.0.0"
-github "ReSwift/ReSwift" "3.0.0"
+github "ReSwift/ReSwift" "6161a8fc55d94c30c5c854c4b22a185074b1c75f"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
-github "Quick/Nimble" "v5.1.1"
-github "Quick/Quick" "v1.0.0"
+github "Quick/Nimble" "v6.0.1"
+github "Quick/Quick" "v1.1.0"
 github "ReSwift/ReSwift" "6161a8fc55d94c30c5c854c4b22a185074b1c75f"

--- a/ReSwiftRouter.xcodeproj/project.pbxproj
+++ b/ReSwiftRouter.xcodeproj/project.pbxproj
@@ -1151,7 +1151,7 @@
 				);
 				INFOPLIST_FILE = ReSwiftRouter/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "de.benjamin-encz.ReSwiftRouter";
 				PRODUCT_NAME = ReSwiftRouter;
@@ -1176,7 +1176,7 @@
 				);
 				INFOPLIST_FILE = ReSwiftRouter/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "de.benjamin-encz.ReSwiftRouter";
 				PRODUCT_NAME = ReSwiftRouter;

--- a/ReSwiftRouter/Routable.swift
+++ b/ReSwiftRouter/Routable.swift
@@ -26,6 +26,11 @@ public protocol Routable {
         animated: Bool,
         completionHandler: @escaping RoutingCompletionHandler) -> Routable
 
+    func canPush(segment: RouteElementIdentifier) -> Bool
+
+    func canPop(segment: RouteElementIdentifier) -> Bool
+
+    func canChange(segment: RouteElementIdentifier) -> Bool
 }
 
 extension Routable {
@@ -52,4 +57,15 @@ extension Routable {
             fatalError("This routable cannot change segments. You have not implemented it.")
     }
 
+    public func canPush(segment: RouteElementIdentifier) -> Bool {
+        return true
+    }
+
+    public func canPop(segment: RouteElementIdentifier) -> Bool {
+        return true
+    }
+
+    public func canChange(segment: RouteElementIdentifier) -> Bool {
+        return true
+    }
 }

--- a/ReSwiftRouter/Router.swift
+++ b/ReSwiftRouter/Router.swift
@@ -60,7 +60,7 @@ open class Router<State: StateType>: StoreSubscriber {
 
                 case let .change(responsibleRoutableIndex, segmentToBeReplaced, newSegment):
                     DispatchQueue.main.async {
-                        let routable = routables[responsibleRoutableIndex]
+                        let routable = self.routables[responsibleRoutableIndex]
                         if routable.canChange(segment: newSegment) {
                             self.routables[responsibleRoutableIndex + 1] =
                                 routable

--- a/ReSwiftRouter/Router.swift
+++ b/ReSwiftRouter/Router.swift
@@ -25,6 +25,27 @@ open class Router<State: StateType>: StoreSubscriber {
         self.store.subscribe(self, selector: stateSelector)
     }
 
+    public func canNavigate(to route: Route) -> Bool {
+        let routingActions = Router.routingActionsForTransitionFrom(
+            lastNavigationState.route,
+            newRoute: route
+        )
+
+        return routingActions.reduce(false) { canRoute, action in
+            switch action {
+            case let .pop(responsibleRoutableIndex, segmentToBePopped):
+                let routable = self.routables[responsibleRoutableIndex]
+                return canRoute || routable.canPop(segment: segmentToBePopped)
+            case let .change(responsibleRoutableIndex, _, newSegment):
+                let routable = self.routables[responsibleRoutableIndex]
+                return canRoute || routable.canChange(segment: newSegment)
+            case let .push(responsibleRoutableIndex, segmentToBePushed):
+                let routable = self.routables[responsibleRoutableIndex]
+                return canRoute || routable.canPush(segment: segmentToBePushed)
+            }
+        }
+    }
+
     open func newState(state: NavigationState) {
         let routingActions = Router.routingActionsForTransitionFrom(
             lastNavigationState.route, newRoute: state.route)

--- a/ReSwiftRouterTests/ReSwiftRouterIntegrationTests.swift
+++ b/ReSwiftRouterTests/ReSwiftRouterIntegrationTests.swift
@@ -198,6 +198,46 @@ class SwiftFlowRouterIntegrationTests: QuickSpec {
                     }
                 }
 
+                it("will call canPush") {
+                    store.dispatch(
+                        SetRouteAction(
+                            ["TabBarViewController"]
+                        )
+                    )
+
+                    class FakeRootRoutable: Routable {
+                        var calledFunction: (String) -> Void
+
+                        init(calledFunction: @escaping (String) -> Void) {
+                            self.calledFunction = calledFunction
+                        }
+
+                        func canPush(segment: RouteElementIdentifier) -> Bool {
+                            calledFunction("canPush")
+                            return false
+                        }
+
+                        func pushRouteSegment(_ routeElementIdentifier: RouteElementIdentifier, animated: Bool, completionHandler: @escaping RoutingCompletionHandler) -> Routable {
+                            calledFunction("pushRouteSegment")
+
+                            completionHandler()
+                            return MockRoutable()
+                        }
+
+                    }
+
+                    waitUntil(timeout: 2.0) { fullfill in
+                        let rootRoutable = FakeRootRoutable { action in
+                            if action == "canPush" {
+                                fullfill()
+                            }
+                        }
+
+                        let _ = Router(store: store, rootRoutable: rootRoutable) { state in
+                            state.navigationState
+                        }
+                    }
+                }
             }
 
         }

--- a/ReSwiftRouterTests/ReSwiftRouterIntegrationTests.swift
+++ b/ReSwiftRouterTests/ReSwiftRouterIntegrationTests.swift
@@ -65,18 +65,14 @@ struct FakeAppState: StateType {
     var navigationState = NavigationState()
 }
 
-class FakeReducer: Reducer {
-    func handleAction(action: Action, state: FakeAppState?) -> FakeAppState {
-        return state ?? FakeAppState()
-    }
+func fakeReducer(action: Action, state: FakeAppState?) -> FakeAppState {
+    return state ?? FakeAppState()
 }
 
-struct AppReducer: Reducer {
-    func handleAction(action: Action, state: FakeAppState?) -> FakeAppState {
-        return FakeAppState(
-            navigationState: NavigationReducer.handleAction(action, state: state?.navigationState)
-        )
-    }
+func appReducer(action: Action, state: FakeAppState?) -> FakeAppState {
+    return FakeAppState(
+        navigationState: NavigationReducer.handleAction(action, state: state?.navigationState)
+    )
 }
 
 class SwiftFlowRouterIntegrationTests: QuickSpec {
@@ -88,7 +84,7 @@ class SwiftFlowRouterIntegrationTests: QuickSpec {
             var store: Store<FakeAppState>!
 
             beforeEach {
-                store = Store(reducer: CombinedReducer([AppReducer()]), state: FakeAppState())
+                store = Store(reducer: appReducer, state: FakeAppState())
             }
 
             describe("setup") {
@@ -248,7 +244,7 @@ class SwiftFlowRouterIntegrationTests: QuickSpec {
             var store: Store<FakeAppState>!
 
             beforeEach {
-                store = Store(reducer: AppReducer(), state: nil)
+                store = Store(reducer: appReducer, state: nil)
             }
 
             context("when setting route specific data") {
@@ -276,7 +272,7 @@ class SwiftFlowRouterIntegrationTests: QuickSpec {
             var router: Router<FakeAppState>!
 
             beforeEach {
-                store = Store(reducer: AppReducer(), state: nil)
+                store = Store(reducer: appReducer, state: nil)
                 mockRoutable = MockRoutable()
                 router = Router(store: store, rootRoutable: mockRoutable) { state in
                     state.navigationState


### PR DESCRIPTION
## The problem encountered

Rather unfortunately our app gets itself into a state whereby we try to perform a `push`, `pop` or `change` action on a route that isn't supported by a routable. This often results in `fatalError` being called and the app crashing.

## A possible solution

This is an idea / attempt at fixing the problem though is unfortunately incomplete. By calling a function defined on the routable before calling `push`, `pop` or `change` we can check whether the action will in fact work. This is a much more desirable result than a `fatalError`.

Unfortunately by having the check in the `Router` which is a store subscriber, it occurs after the navigation state has been updated. This means that we prevent the call resulting in fatalError but we have a state that is not reflective of where the app is.

As such, there's a need to also have a ReSwift Middleware written in the app in order to check whether we can navigate to a route before the state is changed.

## A call for help / suggestions

It would be great to get some discussion and input happening around this change. I'm not 100% sure what the best approach here in fact is.