### PR TITLE
Call pop on the poped routable, not on the previous one (#61)

### DIFF
--- a/ReSwiftRouter/Router.swift
+++ b/ReSwiftRouter/Router.swift
@@ -161,7 +161,7 @@ open class Router<State: StateType>: StoreSubscriber {
             //  we need to pop the route segment after the commonSubroute"
             if oldRoute.count > newRoute.count {
                 let popAction = RoutingActions.pop(
-                    responsibleRoutableIndex: routableIndexForRouteSegment(routeBuildingIndex - 1),
+                    responsibleRoutableIndex: routableIndexForRouteSegment(routeBuildingIndex),
                     segmentToBePopped: oldRoute[routeBuildingIndex]
                 )
 

--- a/ReSwiftRouter/Router.swift
+++ b/ReSwiftRouter/Router.swift
@@ -148,7 +148,7 @@ open class Router<State: StateType>: StoreSubscriber {
                 let routeSegmentToPop = oldRoute[routeBuildingIndex]
 
                 let popAction = RoutingActions.pop(
-                    responsibleRoutableIndex: routableIndexForRouteSegment(routeBuildingIndex - 1),
+                    responsibleRoutableIndex: routableIndexForRouteSegment(routeBuildingIndex),
                     segmentToBePopped: routeSegmentToPop
                 )
 

--- a/ReSwiftRouter/Router.swift
+++ b/ReSwiftRouter/Router.swift
@@ -50,7 +50,7 @@ open class Router<State: StateType>: StoreSubscriber {
                                     semaphore.signal()
                         }
 
-                        self.routables.remove(at: responsibleRoutableIndex + 1)
+                        self.routables.remove(at: responsibleRoutableIndex)
                     }
 
                 case let .change(responsibleRoutableIndex, segmentToBeReplaced, newSegment):


### PR DESCRIPTION
See #61 

I've presented modally `vc2` on `vc1` from `vc1` like this: `SetRouteAction(["VC1id", "VC2id"])`. On `vc1 routable` `pushRouteSegment(_,_,_)` is being called correctly. 
Then,  when I call `SetRouteAction(["VC1id"])` the `popRouteSegment(_,_,_)` is being called on `vc1 routable`, keeping me from calling `vc2.dismiss(_,_)` because I don't have link to `vc2` there. 
What do I do incorrectly, or is it an expected behaviour?