### PR TITLE
Remove Carthage Copy Frameworks build phases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
     - FRAMEWORK_NAME="ReSwiftRouter"
     - UPDATE_DOCS="false"
 
-osx_image: xcode8.2
+osx_image: xcode8.3
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ osx_image: xcode8.3
 matrix:
   include:
       - env: SCHEME="macOS"  SDK="macosx10.12"          DESTINATION="arch=x86_64"
-      - env: SCHEME="iOS"    SDK="iphonesimulator10.2"  DESTINATION="OS=10.1,name=iPhone 6S Plus"
+      - env: SCHEME="iOS"    SDK="iphonesimulator10.3"  DESTINATION="OS=10.3,name=iPhone 6S Plus"
       - env: SCHEME="tvOS"   SDK="appletvsimulator10.1"  DESTINATION="OS=10.1,name=Apple TV 1080p"
 
 before_install:

--- a/ReSwiftRouter.xcodeproj/project.pbxproj
+++ b/ReSwiftRouter.xcodeproj/project.pbxproj
@@ -390,7 +390,6 @@
 				6209C05D1C5427E0004E6B66 /* Frameworks */,
 				6209C05E1C5427E0004E6B66 /* Headers */,
 				6209C05F1C5427E0004E6B66 /* Resources */,
-				D47F3A941E00896B00AAA70A /* Carthage Copy Frameworks */,
 			);
 			buildRules = (
 			);
@@ -428,7 +427,6 @@
 				6209C0841C5428DE004E6B66 /* Frameworks */,
 				6209C0851C5428DE004E6B66 /* Headers */,
 				6209C0861C5428DE004E6B66 /* Resources */,
-				D47F3A601E0087D900AAA70A /* Carthage Copy Frameworks */,
 			);
 			buildRules = (
 			);
@@ -466,7 +464,6 @@
 				625E66C91C1FFE280027C288 /* Frameworks */,
 				625E66CA1C1FFE280027C288 /* Headers */,
 				625E66CB1C1FFE280027C288 /* Resources */,
-				D47F3A551E0085A300AAA70A /* Carthage Copy Frameworks */,
 			);
 			buildRules = (
 			);
@@ -614,21 +611,6 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		D47F3A551E0085A300AAA70A /* Carthage Copy Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"$(SRCROOT)/Carthage/Build/iOS/ReSwift.framework",
-			);
-			name = "Carthage Copy Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "/usr/local/bin/carthage copy-frameworks";
-		};
 		D47F3A581E0086C800AAA70A /* Carthage Copy Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -646,21 +628,6 @@
 			shellPath = /bin/sh;
 			shellScript = "/usr/local/bin/carthage copy-frameworks";
 		};
-		D47F3A601E0087D900AAA70A /* Carthage Copy Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"$(SRCROOT)/Carthage/Build/Mac/ReSwift.framework",
-			);
-			name = "Carthage Copy Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "/usr/local/bin/carthage copy-frameworks";
-		};
 		D47F3A6E1E00881800AAA70A /* Carthage Copy Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -670,21 +637,6 @@
 				"$(SRCROOT)/Carthage/Build/Mac/Nimble.framework",
 				"$(SRCROOT)/Carthage/Build/Mac/Quick.framework",
 				"$(SRCROOT)/Carthage/Build/Mac/ReSwift.framework",
-			);
-			name = "Carthage Copy Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "/usr/local/bin/carthage copy-frameworks";
-		};
-		D47F3A941E00896B00AAA70A /* Carthage Copy Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"$(SRCROOT)/Carthage/Build/tvOS/ReSwift.framework",
 			);
 			name = "Carthage Copy Frameworks";
 			outputPaths = (


### PR DESCRIPTION
### :tophat: What is the goal?

`ReSwift-Router` has `ReSwift` as nested bundles. This when submitted to iTunes Connect trigger the following errors :

- ITMS-90205 - Invalid Bundle
- ITMS-90206 - Invalid Bundle

This PR address this issue.

### How is it being implemented?

Remove Carthage Copy Frameworks build phases.
The app target is responsible to have a `Copy Frameworks` build phase in order to include all required dependencies