### PR TITLE
Interop with UINavigationController user instantiated popping

### DIFF
--- a/ReSwiftRouter.xcodeproj/project.pbxproj
+++ b/ReSwiftRouter.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1ADD0D9B1F041625004B2FD7 /* NavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1ADD0D9A1F041625004B2FD7 /* NavigationController.swift */; };
 		254B3BAD1D3AD6DD00B1E4F0 /* RouteHashSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 254B3BAC1D3AD6DD00B1E4F0 /* RouteHashSpec.swift */; };
 		254B3BAE1D3AD6DD00B1E4F0 /* RouteHashSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 254B3BAC1D3AD6DD00B1E4F0 /* RouteHashSpec.swift */; };
 		254B3BAF1D3AD6DD00B1E4F0 /* RouteHashSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 254B3BAC1D3AD6DD00B1E4F0 /* RouteHashSpec.swift */; };
@@ -94,6 +95,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		1ADD0D9A1F041625004B2FD7 /* NavigationController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NavigationController.swift; path = ReSwiftRouter/NavigationController.swift; sourceTree = SOURCE_ROOT; };
 		254B3BAC1D3AD6DD00B1E4F0 /* RouteHashSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RouteHashSpec.swift; path = ReSwiftRouterTests/RouteHashSpec.swift; sourceTree = SOURCE_ROOT; };
 		25C0A9C51C50AF6400139FA7 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = ReSwiftRouter/Info.plist; sourceTree = SOURCE_ROOT; };
 		25C0A9C61C50AF6400139FA7 /* NavigationActions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NavigationActions.swift; path = ReSwiftRouter/NavigationActions.swift; sourceTree = SOURCE_ROOT; };
@@ -220,6 +222,7 @@
 				25C0A9C61C50AF6400139FA7 /* NavigationActions.swift */,
 				25C0A9C71C50AF6400139FA7 /* NavigationReducer.swift */,
 				25C0A9C81C50AF6400139FA7 /* NavigationState.swift */,
+				1ADD0D9A1F041625004B2FD7 /* NavigationController.swift */,
 				25C0A9C91C50AF6400139FA7 /* ReSwiftRouter.h */,
 				25C0A9CA1C50AF6400139FA7 /* Routable.swift */,
 				25C0A9CB1C50AF6400139FA7 /* Router.swift */,
@@ -774,6 +777,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				25C0A9CE1C50AF6400139FA7 /* NavigationReducer.swift in Sources */,
+				1ADD0D9B1F041625004B2FD7 /* NavigationController.swift in Sources */,
 				25C0A9CF1C50AF6400139FA7 /* NavigationState.swift in Sources */,
 				25C0A9D21C50AF6400139FA7 /* Router.swift in Sources */,
 				25C0A9CD1C50AF6400139FA7 /* NavigationActions.swift in Sources */,

--- a/ReSwiftRouter/NavigationController.swift
+++ b/ReSwiftRouter/NavigationController.swift
@@ -1,0 +1,37 @@
+//
+//  NavigationController.swift
+//  ReSwiftRouter
+//
+//  Created by Taras Vozniuk on 29/06/2017.
+//  Copyright © 2017 Benjamin Encz. All rights reserved.
+//
+
+import UIKit
+
+extension UINavigationController {
+    
+    func pushViewController(_ viewController: UIViewController, animated: Bool, completion: @escaping () -> Void) {
+        
+        self.pushViewController(viewController, animated: animated)
+        
+        guard animated, let coordinator = self.transitionCoordinator else {
+            completion()
+            return
+        }
+        
+        coordinator.animate(alongsideTransition: nil) { _ in completion() }
+    }
+    
+    func popViewController(animated: Bool, completion: @escaping () -> Void) -> UIViewController? {
+        
+        let popped = self.popViewController(animated: animated)
+        
+        guard animated, let coordinator = self.transitionCoordinator else {
+            completion()
+            return popped
+        }
+        
+        coordinator.animate(alongsideTransition: nil) { _ in completion() }
+        return popped
+    }
+}

--- a/ReSwiftRouter/NavigationController.swift
+++ b/ReSwiftRouter/NavigationController.swift
@@ -8,6 +8,73 @@
 
 import UIKit
 
+// dummy view controller returned when popViewController is canceled
+final class PopWasIgnored: UIViewController {}
+
+open class NavigationController: UINavigationController {
+    
+    fileprivate var isSwipping: Bool = false
+    
+    // indicates that backButton was pressed when set to false
+    fileprivate var isPerformingPop: Bool = false
+    
+    override open func viewDidLoad() {
+        super.viewDidLoad()
+        self.interactivePopGestureRecognizer?.addTarget(self, action: #selector(NavigationController.handlePopSwipe))
+        self.delegate = self
+    }
+    
+    override open func popViewController(animated: Bool) -> UIViewController? {
+        
+        // when swipping we are discarding all subsequent popViewController calls
+        guard !self.isSwipping else {
+            return PopWasIgnored()
+        }
+        
+        self.isPerformingPop = true
+        return super.popViewController(animated: animated)
+    }
+    
+    // will be called after popViewController call
+    func handlePopSwipe(){
+        self.isSwipping = true
+    }
+    
+    /// should be overriden
+    /// normally you should dispatch SetRouteAction here
+    open func changeRoute(){
+        print("WARNING: \(#function) should to be overriden")
+    }
+}
+
+extension NavigationController: UINavigationControllerDelegate {
+    
+    public func navigationController(_ navigationController: UINavigationController, didShow viewController: UIViewController, animated: Bool) {
+        self.isSwipping = false
+    }
+}
+
+extension NavigationController: UINavigationBarDelegate {
+    
+    // if overriden navigationController popViewController won't be called before this method
+    // on back button press
+    // isPerformingPop will be false here in this case
+    public func navigationBar(_ navigationBar: UINavigationBar, shouldPop item: UINavigationItem) -> Bool {
+        defer { isPerformingPop = false }
+        
+        // changeRoute is performed:
+        // 1. back button was pressed
+        // 2. pop swipe is triggerred
+        if !isPerformingPop || self.isSwipping {
+            self.changeRoute()
+        }
+        
+        // don't remove the navigationItem if navigationController
+        // is not going to be popped
+        return isPerformingPop
+    }
+}
+
 extension UINavigationController {
     
     func pushViewController(_ viewController: UIViewController, animated: Bool, completion: @escaping () -> Void) {

--- a/ReSwiftRouter/NavigationController.swift
+++ b/ReSwiftRouter/NavigationController.swift
@@ -77,7 +77,7 @@ extension NavigationController: UINavigationBarDelegate {
 
 extension UINavigationController {
     
-    func pushViewController(_ viewController: UIViewController, animated: Bool, completion: @escaping () -> Void) {
+    open func pushViewController(_ viewController: UIViewController, animated: Bool, completion: @escaping () -> Void) {
         
         self.pushViewController(viewController, animated: animated)
         
@@ -89,7 +89,7 @@ extension UINavigationController {
         coordinator.animate(alongsideTransition: nil) { _ in completion() }
     }
     
-    func popViewController(animated: Bool, completion: @escaping () -> Void) -> UIViewController? {
+    open func popViewController(animated: Bool, completion: @escaping () -> Void) -> UIViewController? {
         
         let popped = self.popViewController(animated: animated)
         

--- a/ReSwiftRouter/NavigationController.swift
+++ b/ReSwiftRouter/NavigationController.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 // dummy view controller returned when popViewController is canceled
-final class PopWasIgnored: UIViewController {}
+public final class PopWasIgnored: UIViewController {}
 
 open class NavigationController: UINavigationController {
     
@@ -42,7 +42,7 @@ open class NavigationController: UINavigationController {
     
     /// should be overriden
     /// normally you should dispatch SetRouteAction here
-    open func changeRoute(){
+    open func popRoute(){
         print("WARNING: \(#function) should to be overriden")
     }
 }
@@ -64,9 +64,9 @@ extension NavigationController: UINavigationBarDelegate {
         
         // changeRoute is performed:
         // 1. back button was pressed
-        // 2. pop swipe is triggerred
+        // 2. pop swipe was triggerred
         if !isPerformingPop || self.isSwipping {
-            self.changeRoute()
+            self.popRoute()
         }
         
         // don't remove the navigationItem if navigationController


### PR DESCRIPTION
**Motivation:**
`ReSwiftRouter` should provide the optional mechanism that assists in triggering of route pop corresponding actions to the store when:

1. User hits the back button on the navigation bar
2. User swipes over the left edge of the screen

**API Proposal:**
Users needs to subclass the ReSwiftInit.NavigationController and override popRoute() methods where they specify the dispatch logic to their store. Like:

```swift
class RootNavigationController: ReSwiftRouter.NavigationController {
    override func popRoute() {
        let currentRoute = mainStore.state.navigationState.route
        
        guard currentRoute.startIndex != currentRoute.endIndex else {
            return
        }
        
        mainStore <- SetRouteAction([RouteElementIdentifier](currentRoute[currentRoute.startIndex ..< currentRoute.endIndex.advanced(by: -1)]))
    }
}
```

**Implementation details:**
When user hits the back button `popViewController()` can be canceled if `navigationBar(:shouldPop item:)` is implemented. In such case `popRoute()` will be called that should result in `SetRouteAction` dispatched. Our routable can then subsequently call the actual `popViewController()` as desired. 

However, when swiping `popViewContoller()` call cannot be canceled. When swipe is recognized, `popViewController()` will be called before `popRoute()` callback. In order to avoid the redundant `popViewController()` from our routable, `popViewController()` semantics was changed to ignore all `popViewController()` calls when swipe is still in progress. This semantic change is reasonable since nothing should be calling `popViewController()` while user is swiping anyway. Also it allows us having our routable transparent of the swiping state. It can instead (if needed) check if pop was canceled since the instance of `PopWasCancelled` dummy viewController would be returned. Like:
```swift
let popped = mapViewController.navigationController?.popViewController(animated: animated, completion: completionHandler)
if popped is PopWasIgnored {
       //additional logic on cancelation during swipe
}
```

Additionally the utility navigationController's push/pop with completion were provided.
The sample hypothetical routable can use it like:
```swift
public func popRouteSegment(_ routeElementIdentifier: RouteElementIdentifier, animated: Bool, completionHandler: @escaping ReSwiftRouter.RoutingCompletionHandler) {
        
    guard routeElementIdentifier == Routes.editFeature else {
         completionHandler()
         return
    }
        
    _ = mapViewController.navigationController?.popViewController(animated: animated, completion: completionHandler)
}
```