### PR TITLE
Fix Readme configuration section for Router instance 0.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ After you've initialized your store, create an instance of `Router`, passing in 
 
 ```swift
 router = Router(store: mainStore, rootRoutable: RootRoutable(routable: rootViewController)) { state in 
-	state.navigationState
+	state.select { $0.navigationState }
 }
 ```
 


### PR DESCRIPTION
The configuration section of the readme contained out-dated (in 0.6.0)
code example on how to create an instance of Router