### PR TITLE
Provide more information on Routable fatalErrors

### DIFF
--- a/ReSwiftRouter/Routable.swift
+++ b/ReSwiftRouter/Routable.swift
@@ -34,14 +34,14 @@ extension Routable {
         _ routeElementIdentifier: RouteElementIdentifier,
         animated: Bool,
         completionHandler: @escaping RoutingCompletionHandler) -> Routable {
-            fatalError("This routable cannot change segments. You have not implemented it.")
+            fatalError("This routable cannot push segments. You have not implemented it. (Asked \(type(of: self)) to push \(routeElementIdentifier))")
     }
 
     public func popRouteSegment(
         _ routeElementIdentifier: RouteElementIdentifier,
         animated: Bool,
         completionHandler: @escaping RoutingCompletionHandler) {
-            fatalError("This routable cannot change segments. You have not implemented it.")
+            fatalError("This routable cannot pop segments. You have not implemented it. (Asked \(type(of: self)) to pop \(routeElementIdentifier))")
     }
 
     public func changeRouteSegment(
@@ -49,7 +49,7 @@ extension Routable {
         to: RouteElementIdentifier,
         animated: Bool,
         completionHandler: @escaping RoutingCompletionHandler) -> Routable {
-            fatalError("This routable cannot change segments. You have not implemented it.")
+            fatalError("This routable cannot change segments. You have not implemented it. (Asked \(type(of: self)) to change from \(from) to \(to))")
     }
 
 }


### PR DESCRIPTION
The default implementation for the function to push, pop, and change provided via protocol extension fatalErrors to notify developers that they haven't provided the required implementation.

The message used in the fatalError was not informative enough. These changes make it granular to the actual function being used, as well as adding the type that caused the failure, and the route element parameters that the code was trying to act on.

The new error message for push for example will look something like:

```
This routable cannot push segments. You have not implemented it.
(Asked RootRoutable to push landing)
```