### PR TITLE
Added push and pop actions

### DIFF
--- a/Cartfile.private
+++ b/Cartfile.private
@@ -3,4 +3,4 @@ github "Quick/Quick"
 # Release 7.0.1 produces a build error due to using a `swift-version` argument
 # See: https://github.com/Quick/Nimble/issues/434
 # As of now fix has not been released yet.
-github "Quick/Nimble"  == 7.0.0
+github "Quick/Nimble"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
-github "Quick/Nimble" "v7.0.0"
-github "Quick/Quick" "v1.1.0"
-github "ReSwift/ReSwift" "4.0.0"
+github "Quick/Nimble" "v7.0.3"
+github "Quick/Quick" "v1.2.0"
+github "ReSwift/ReSwift" "4.0.1"

--- a/ReSwiftRouter/NavigationActions.swift
+++ b/ReSwiftRouter/NavigationActions.swift
@@ -39,11 +39,59 @@ public struct SetRouteAction: StandardActionConvertible {
 }
 
 public struct SetRouteSpecificData: Action {
+
     let route: Route
     let data: Any
 
     public init(route: Route, data: Any) {
         self.route = route
         self.data = data
+    }
+}
+
+public struct PushPathAction: StandardActionConvertible {
+
+    let path: RouteElementIdentifier
+    let animated: Bool
+    public static let type = "RE_SWIFT_ROUTER_PUSH_PATH"
+
+    public init(_ path: RouteElementIdentifier, animated: Bool = true) {
+        self.path = path
+        self.animated = animated
+    }
+
+    public init(_ action: StandardAction) {
+        self.path = action.payload!["path"] as! RouteElementIdentifier
+        self.animated = action.payload!["animated"] as! Bool
+    }
+
+    public func toStandardAction() -> StandardAction {
+        return StandardAction(
+            type: PushPathAction.type,
+            payload: ["path": path as AnyObject, "animated": animated as AnyObject],
+            isTypedAction: true
+        )
+    }
+}
+
+public struct PopPathAction: StandardActionConvertible {
+
+    let animated: Bool
+    public static let type = "RE_SWIFT_ROUTER_POP_PATH"
+
+    public init(animated: Bool = true) {
+        self.animated = animated
+    }
+
+    public init(_ action: StandardAction) {
+        self.animated = action.payload!["animated"] as! Bool
+    }
+
+    public func toStandardAction() -> StandardAction {
+        return StandardAction(
+            type: PushPathAction.type,
+            payload: ["animated": animated as AnyObject],
+            isTypedAction: true
+        )
     }
 }

--- a/ReSwiftRouter/NavigationReducer.swift
+++ b/ReSwiftRouter/NavigationReducer.swift
@@ -22,6 +22,10 @@ public struct NavigationReducer {
         switch action {
         case let action as SetRouteAction:
             return setRoute(state, setRouteAction: action)
+        case let action as PushPathAction:
+            return pushPath(state, pushPathAction: action)
+        case let action as PopPathAction:
+            return popPath(state, popPathAction: action)
         case let action as SetRouteSpecificData:
             return setRouteSpecificData(state, route: action.route, data: action.data)
         default:
@@ -36,6 +40,24 @@ public struct NavigationReducer {
 
         state.route = setRouteAction.route
         state.changeRouteAnimated = setRouteAction.animated
+
+        return state
+    }
+
+    static func pushPath(_ state: NavigationState, pushPathAction: PushPathAction) -> NavigationState {
+        var state = state
+
+        state.route.append(pushPathAction.path)
+        state.changeRouteAnimated = pushPathAction.animated
+
+        return state
+    }
+
+    static func popPath(_ state: NavigationState, popPathAction: PopPathAction) -> NavigationState {
+        var state = state
+
+        state.route = Array(state.route.dropLast())
+        state.changeRouteAnimated = popPathAction.animated
 
         return state
     }

--- a/ReSwiftRouterTests/ReSwiftRouterIntegrationTests.swift
+++ b/ReSwiftRouterTests/ReSwiftRouterIntegrationTests.swift
@@ -273,9 +273,29 @@ class SwiftFlowRouterIntegrationTests: QuickSpec {
                     expect(mockRoutable.callsToPushRouteSegment.last?.animated).toEventually(beTrue())
                 }
             }
+
+            context("when dispatching a push route path change") {
+                beforeEach {
+                    store.dispatch(PushPathAction("someRoute"))
+                }
+
+                it("calls routables asking for an animated presentation") {
+                    expect(mockRoutable.callsToPushRouteSegment.last?.animated).toEventually(beTrue())
+                }
+            }
+
+            context("when dispatching a pop route path change") {
+                beforeEach {
+                    store.dispatch(PushPathAction("someRoute"))
+                    store.dispatch(PopPathAction())
+                }
+
+                it("calls routables asking for an animated presentation") {
+                    expect(mockRoutable.callsToPopRouteSegment.last?.animated).toEventually(beTrue())
+                }
+            }
+
         }
-
-
     }
     
 }


### PR DESCRIPTION
I have added actions to allow developers to add or remove single RouteElements. Instead of always passing the absolute route.

I don't know if this is the best way to handle it. But I am all ears for improvements.