### PR TITLE
Grouped Pop actions

### DIFF
--- a/ReSwiftRouter/NavigationActions.swift
+++ b/ReSwiftRouter/NavigationActions.swift
@@ -16,22 +16,25 @@ public struct SetRouteAction: StandardActionConvertible {
 
     let route: Route
     let animated: Bool
+    let groupPops: Bool
     public static let type = "RE_SWIFT_ROUTER_SET_ROUTE"
 
-    public init (_ route: Route, animated: Bool = true) {
+    public init (_ route: Route, animated: Bool = true, groupPops: Bool = false) {
         self.route = route
         self.animated = animated
+        self.groupPops = groupPops
     }
 
     public init(_ action: StandardAction) {
         self.route = action.payload!["route"] as! Route
         self.animated = action.payload!["animated"] as! Bool
+        self.groupPops = action.payload!["groupPops"] as! Bool
     }
 
     public func toStandardAction() -> StandardAction {
         return StandardAction(
             type: SetRouteAction.type,
-            payload: ["route": route as AnyObject, "animated": animated as AnyObject],
+            payload: ["route": route as AnyObject, "animated": animated as AnyObject, "groupPops": groupPops as AnyObject],
             isTypedAction: true
         )
     }

--- a/ReSwiftRouter/NavigationReducer.swift
+++ b/ReSwiftRouter/NavigationReducer.swift
@@ -36,6 +36,7 @@ public struct NavigationReducer {
 
         state.route = setRouteAction.route
         state.changeRouteAnimated = setRouteAction.animated
+        state.groupPops = setRouteAction.groupPops
 
         return state
     }

--- a/ReSwiftRouter/NavigationState.swift
+++ b/ReSwiftRouter/NavigationState.swift
@@ -33,6 +33,7 @@ public struct NavigationState {
     public var route: Route = []
     public var routeSpecificState: [RouteHash: Any] = [:]
     var changeRouteAnimated: Bool = true
+    var groupPops: Bool = false
 }
 
 extension NavigationState {

--- a/ReSwiftRouter/Routable.swift
+++ b/ReSwiftRouter/Routable.swift
@@ -20,6 +20,11 @@ public protocol Routable {
         animated: Bool,
         completionHandler: @escaping RoutingCompletionHandler)
 
+    func popRouteSegments(
+            _ routeElementIdentifiers: [RouteElementIdentifier],
+            animated: Bool,
+            completionHandler: @escaping RoutingCompletionHandler)
+
     func changeRouteSegment(
         _ from: RouteElementIdentifier,
         to: RouteElementIdentifier,
@@ -42,6 +47,13 @@ extension Routable {
         animated: Bool,
         completionHandler: @escaping RoutingCompletionHandler) {
             fatalError("This routable cannot pop segments. You have not implemented it. (Asked \(type(of: self)) to pop \(routeElementIdentifier))")
+    }
+
+    public func popRouteSegments(
+            _ routeElementIdentifiers: [RouteElementIdentifier],
+            animated: Bool,
+            completionHandler: @escaping RoutingCompletionHandler) {
+        fatalError("This routable cannot popTo segments. You have not implemented it. (Asked \(type(of: self)) to pop \(routeElementIdentifiers))")
     }
 
     public func changeRouteSegment(

--- a/ReSwiftRouter/Router.swift
+++ b/ReSwiftRouter/Router.swift
@@ -194,16 +194,19 @@ open class Router<State: StateType>: StoreSubscriber {
 
         if groupPops {
             routingActions = routingActions.reduce([]) { acc, item in
-                if case let .pop(popRoutableIndex, segmentToBePopped) = item {
+                if case let .pop(responsibleRoutableIndex, segmentToBePopped) = item {
                     switch acc.last {
-                    case let .some(.popGroup(_, segmentsToBePopped)):
+                    case let .some(.popGroup(_, prevSegmentsToBePopped)):
                         return Array(acc.dropLast()) + [RoutingActions
-                                .popGroup(responsibleRoutableIndex: popRoutableIndex,
-                                segmentsToBePopped: segmentsToBePopped + [segmentToBePopped])]
+                                .popGroup(responsibleRoutableIndex: responsibleRoutableIndex,
+                                segmentsToBePopped: prevSegmentsToBePopped + [segmentToBePopped])]
+
+                    case let .some(.pop(_, prevSegmentToBePopped)):
+                        return Array(acc.dropLast()) + [RoutingActions
+                                .popGroup(responsibleRoutableIndex: responsibleRoutableIndex,
+                                segmentsToBePopped: [prevSegmentToBePopped] + [segmentToBePopped])]
                     default:
-                        return acc + [RoutingActions
-                                .popGroup(responsibleRoutableIndex: popRoutableIndex,
-                                segmentsToBePopped: [segmentToBePopped])]
+                        break
                     }
                 }
                 return acc + [item]


### PR DESCRIPTION
I needed a way to pop directly from a view to a certain ascendant view, without triggering every individual pop.
Ended up adding a new function to the `Routable` protocol called `popRouteSegments` (note the 's' at the end), that is used whenever the `groupPops` variable is enabled at the navigation state. It is triggered whenever there are more than one `pop` happening in sequence.

You can then implement that `popRouteSegments` on your routables, and call `popToViewController` or `popToRootViewControllerAnimated`.