### PR TITLE
Change Swift Package Manager product from executible to library

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
     name: "ReSwift-Router",
     products: [
-      .executable(name: "ReSwift-Router", targets: ["ReSwiftRouter"]),
+      .library(name: "ReSwift-Router", targets: ["ReSwiftRouter"]),
     ],
     dependencies: [
       .package(url: "https://github.com/ReSwift/ReSwift", .upToNextMajor(from: "4.0.1"))


### PR DESCRIPTION
According to the [Swift PM usage docs](https://github.com/apple/swift-package-manager/blob/master/Documentation/Usage.md#create-a-package) this should be a library, not an executable. Executables are for "creating native binary which can be executed from command line" whereas libraries are "contain code which other packages can use and depend on."