### PR TITLE
Update to Swift 5 and Fix Carthage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,13 @@ env:
     - FRAMEWORK_NAME="ReSwiftRouter"
     - UPDATE_DOCS="false"
 
-osx_image: xcode10
+osx_image: xcode10.2
 
 matrix:
   include:
     - env: SCHEME="macOS"  SDK="macosx10.14"          DESTINATION="arch=x86_64"
-    - env: SCHEME="iOS"    SDK="iphonesimulator12.0"  DESTINATION="OS=12.0,name=iPhone X"
-    - env: SCHEME="tvOS"   SDK="appletvsimulator12.0"  DESTINATION="OS=10.2,name=Apple TV 1080p"
+    - env: SCHEME="iOS"    SDK="iphonesimulator12.2"  DESTINATION="OS=12.2,name=iPhone X"
+    - env: SCHEME="tvOS"   SDK="appletvsimulator12.2"  DESTINATION="OS=10.2,name=Apple TV 1080p"
 
 before_install:
   - carthage bootstrap --platform "$SCHEME" --verbose

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "ReSwift/ReSwift" ~> 4.0.0
+github "ReSwift/ReSwift" ~> 4.1.1

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
-github "Quick/Nimble" "v7.3.1"
-github "Quick/Quick" "v1.3.2"
-github "ReSwift/ReSwift" "4.0.1"
+github "Quick/Nimble" "v8.0.1"
+github "Quick/Quick" "v2.1.0"
+github "ReSwift/ReSwift" "4.1.1"

--- a/Package.swift
+++ b/Package.swift
@@ -5,10 +5,10 @@ import PackageDescription
 let package = Package(
     name: "ReSwift-Router",
     products: [
-      .executable(name: "ReSwift-Router", targets: ["ReSwiftRouter"]),
+      .library(name: "ReSwift-Router", targets: ["ReSwiftRouter"]),
     ],
     dependencies: [
-      .package(url: "https://github.com/ReSwift/ReSwift", .upToNextMajor(from: "4.0.1"))
+      .package(url: "https://github.com/ReSwift/ReSwift.git", .upToNextMajor(from: "4.1.1"))
     ],
     targets: [
       .target(

--- a/ReSwiftRouter.podspec
+++ b/ReSwiftRouter.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "ReSwiftRouter"
-  s.version          = "0.6.0"
+  s.version          = "0.6.1"
   s.summary          = "Declarative Routing for ReSwift"
   s.description      = <<-DESC
                           A declarative router for ReSwift. Allows developers to declare routes in a similar manner as
@@ -18,5 +18,5 @@ Pod::Spec.new do |s|
   s.watchos.deployment_target = '2.0'
   s.requires_arc = true
   s.source_files     = 'ReSwiftRouter/**/*.swift'
-  s.dependency 'ReSwift', '~> 4.0.0'
+  s.dependency 'ReSwift', '~> 4.1.1'
 end

--- a/ReSwiftRouter.xcodeproj/project.pbxproj
+++ b/ReSwiftRouter.xcodeproj/project.pbxproj
@@ -1030,7 +1030,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -1082,7 +1082,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";

--- a/ReSwiftRouter/Info.plist
+++ b/ReSwiftRouter/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/ReSwiftRouter/NavigationState.swift
+++ b/ReSwiftRouter/NavigationState.swift
@@ -20,7 +20,9 @@ public struct RouteHash: Hashable {
         self.routeHash = route.joined(separator: "/")
     }
 
-    public var hashValue: Int { return self.routeHash.hashValue }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(routeHash)
+    }
 }
 
 public func == (lhs: RouteHash, rhs: RouteHash) -> Bool {


### PR DESCRIPTION
- update dependencies (ReSwift 4.1.1, Nimble 8.0.1, Quick 2.1.0)
- use Swift 5 as the language version
- use `hash(into:)` instead of deprecated `hashValue`
- set version to 0.6.1
- set as `library` instead of `executable` in Package.swift
- update Travis to use Xcode 10.2 image and iOS/tvOS 12.2 SDKs