### PR TITLE
Fixed the issue #88 -- when the route changes where the old route is …

### DIFF
--- a/ReSwiftRouter/Router.swift
+++ b/ReSwiftRouter/Router.swift
@@ -156,10 +156,21 @@ open class Router<State: StateType>: StoreSubscriber {
                 routeBuildingIndex -= 1
             }
 
+            // This is the 3. case:
+            // "The new route has a different element after the commonSubroute, we need to replace
+            //  the old route element with the new one"
+             if oldRoute.count > (commonSubroute + 1) && newRoute.count > (commonSubroute + 1) {
+                let changeAction = RoutingActions.change(
+                    responsibleRoutableIndex: routableIndex(for: commonSubroute),
+                    segmentToBeReplaced: oldRoute[commonSubroute + 1],
+                    newSegment: newRoute[commonSubroute + 1])
+                
+                routingActions.append(changeAction)
+            }
             // This is the 1. case:
             // "The old route had an element after the commonSubroute and the new route does not
             //  we need to pop the route segment after the commonSubroute"
-            if oldRoute.count > newRoute.count {
+            else if oldRoute.count > newRoute.count {
                 let popAction = RoutingActions.pop(
                     responsibleRoutableIndex: routableIndex(for: routeBuildingIndex - 1),
                     segmentToBePopped: oldRoute[routeBuildingIndex]
@@ -168,17 +179,7 @@ open class Router<State: StateType>: StoreSubscriber {
                 routingActions.append(popAction)
                 routeBuildingIndex -= 1
             }
-            // This is the 3. case:
-            // "The new route has a different element after the commonSubroute, we need to replace
-            //  the old route element with the new one"
-            else if oldRoute.count > (commonSubroute + 1) && newRoute.count > (commonSubroute + 1) {
-                let changeAction = RoutingActions.change(
-                    responsibleRoutableIndex: routableIndex(for: commonSubroute),
-                    segmentToBeReplaced: oldRoute[commonSubroute + 1],
-                    newSegment: newRoute[commonSubroute + 1])
-
-                routingActions.append(changeAction)
-            }
+        
 
             // Push remainder of elements in new Route that weren't in old Route, this covers
             // the 2. case:

--- a/ReSwiftRouterTests/ReSwiftRouterTestsUnitTests.swift
+++ b/ReSwiftRouterTests/ReSwiftRouterTestsUnitTests.swift
@@ -58,7 +58,8 @@ class ReSwiftRouterUnitTests: QuickSpec {
                 expect(action2Correct).to(beTrue())
             }
 
-            it("generates a Change action on the last common subroute") {
+            it("generates a Change on the last common subroute for routes of same length") {
+            
                 let oldRoute = [tabBarViewControllerIdentifier, counterViewControllerIdentifier]
                 let newRoute = [tabBarViewControllerIdentifier, statsViewControllerIdentifier]
 
@@ -83,7 +84,7 @@ class ReSwiftRouterUnitTests: QuickSpec {
                 expect(new).to(equal(statsViewControllerIdentifier))
             }
 
-            it("generates a Change action on the last common subroute, also for routes of different length") {
+            it("generates a Change on the last common subroute when new route is longer than the old route") {
                 let oldRoute = [tabBarViewControllerIdentifier, counterViewControllerIdentifier]
                 let newRoute = [tabBarViewControllerIdentifier, statsViewControllerIdentifier,
                     infoViewControllerIdentifier]
@@ -120,7 +121,7 @@ class ReSwiftRouterUnitTests: QuickSpec {
                 expect(action2Correct).to(beTrue())
             }
             
-            it("generates a Change action on the last common subroute, also for routes of different length, old route is longer than the new one") {
+            it("generates a Change on the last common subroute when the new route is shorter than the old route") {
                 let oldRoute = [tabBarViewControllerIdentifier, counterViewControllerIdentifier,infoViewControllerIdentifier]
                 let newRoute = [tabBarViewControllerIdentifier, statsViewControllerIdentifier]
                 

--- a/ReSwiftRouterTests/ReSwiftRouterTestsUnitTests.swift
+++ b/ReSwiftRouterTests/ReSwiftRouterTestsUnitTests.swift
@@ -119,6 +119,42 @@ class ReSwiftRouterUnitTests: QuickSpec {
                 expect(action1Correct).to(beTrue())
                 expect(action2Correct).to(beTrue())
             }
+            
+            it("generates a Change action on the last common subroute, also for routes of different length, old route is longer than the new one") {
+                let oldRoute = [tabBarViewControllerIdentifier, counterViewControllerIdentifier,infoViewControllerIdentifier]
+                let newRoute = [tabBarViewControllerIdentifier, statsViewControllerIdentifier]
+                
+                let routingActions = Router<AppState>.routingActionsForTransition(from: oldRoute,
+                                                                                  to: newRoute)
+                
+                var action1Correct: Bool?
+                var action2Correct: Bool?
+                
+                if case let RoutingActions.pop(responsibleRoutableIndex, segmentToBePopped)
+                    = routingActions[0] {
+                    
+                    if responsibleRoutableIndex == 2
+                        && segmentToBePopped == infoViewControllerIdentifier {
+                        
+                        action1Correct = true
+                    }
+                }
+                
+                if case let RoutingActions.change(responsibleRoutableIndex, segmentToBeReplaced,
+                                                  newSegment)
+                    = routingActions[1] {
+                    
+                    if responsibleRoutableIndex == 1
+                        && segmentToBeReplaced == counterViewControllerIdentifier
+                        && newSegment == statsViewControllerIdentifier{
+                        action2Correct = true
+                    }
+                }
+                
+                expect(routingActions).to(haveCount(2))
+                expect(action1Correct).to(beTrue())
+                expect(action2Correct).to(beTrue())
+            }
 
             it("generates a Change action on root when root element changes") {
                 let oldRoute = [tabBarViewControllerIdentifier]


### PR DESCRIPTION
Fixed the issue #88 -- when the route changes where the old route is longer than the new route

Refer to the [issue#88](https://github.com/ReSwift/ReSwift-Router/issues/88)  for the complete explanation of the issue.
This issue is fixed in [ReKotlin-Router](https://github.com/ReKotlin/rekotlin-router) as well, refer [here](https://github.com/ReKotlin/rekotlin-router/blob/master/rekotlin-router/src/main/java/org/rekotlinrouter/Router.kt) for more details.