### PR TITLE
Optional disable of pop action on setting route

### DIFF
--- a/ReSwiftRouter/NavigationActions.swift
+++ b/ReSwiftRouter/NavigationActions.swift
@@ -12,11 +12,13 @@ public struct SetRouteAction: Action {
 
     let route: Route
     let animated: Bool
+    let disablePopAction: Bool
     public static let type = "RE_SWIFT_ROUTER_SET_ROUTE"
 
-    public init (_ route: Route, animated: Bool = true) {
+    public init (_ route: Route, animated: Bool = true, disablePopAction: Bool = false) {
         self.route = route
         self.animated = animated
+        self.disablePopAction = disablePopAction
     }
     
 }
@@ -30,3 +32,5 @@ public struct SetRouteSpecificData: Action {
         self.data = data
     }
 }
+
+public struct EnablePopAction: Action {}

--- a/ReSwiftRouter/NavigationReducer.swift
+++ b/ReSwiftRouter/NavigationReducer.swift
@@ -24,6 +24,8 @@ public struct NavigationReducer {
             return setRoute(state, setRouteAction: action)
         case let action as SetRouteSpecificData:
             return setRouteSpecificData(state, route: action.route, data: action.data)
+        case let action as EnablePopAction:
+            return enablePopAction(state)
         default:
             break
         }
@@ -36,6 +38,7 @@ public struct NavigationReducer {
 
         state.route = setRouteAction.route
         state.changeRouteAnimated = setRouteAction.animated
+        state.disablePopAction = setRouteAction.disablePopAction
 
         return state
     }
@@ -51,6 +54,14 @@ public struct NavigationReducer {
             state.routeSpecificState[routeHash] = data
 
             return state
+    }
+    
+    static func enablePopAction(_ state: NavigationState) -> NavigationState {
+        var state = state;
+        
+        state.disablePopAction = false
+        
+        return state
     }
 
 }

--- a/ReSwiftRouter/NavigationState.swift
+++ b/ReSwiftRouter/NavigationState.swift
@@ -35,6 +35,7 @@ public struct NavigationState {
     public var route: Route = []
     public var routeSpecificState: [RouteHash: Any] = [:]
     var changeRouteAnimated: Bool = true
+    var disablePopAction: Bool = false
 }
 
 extension NavigationState {

--- a/ReSwiftRouter/Router.swift
+++ b/ReSwiftRouter/Router.swift
@@ -42,13 +42,17 @@ open class Router<State: StateType>: StoreSubscriber {
 
                 case let .pop(responsibleRoutableIndex, elementToBePopped):
                     DispatchQueue.main.async {
-                        self.routables[responsibleRoutableIndex]
-                            .pop(
-                                elementToBePopped,
-                                animated: state.changeRouteAnimated) {
-                                    semaphore.signal()
+                        if !state.disablePopAction {
+                            self.routables[responsibleRoutableIndex]
+                                .pop(
+                                    elementToBePopped,
+                                    animated: state.changeRouteAnimated) {
+                                        semaphore.signal()
+                            }
+                        } else {
+                            semaphore.signal()
                         }
-
+                        
                         self.routables.remove(at: responsibleRoutableIndex + 1)
                     }
 
@@ -92,8 +96,13 @@ open class Router<State: StateType>: StoreSubscriber {
             }
 
         }
-
+        
         lastNavigationState = state
+        
+        if (state.disablePopAction) {
+            store.dispatch(EnablePopAction())
+        }
+
     }
 
     // MARK: Route Transformation Logic


### PR DESCRIPTION
I started playing around with this router for a WatchKit app I'm going to be working on. I realised that the router could not handle back button / swipe left navigation patterns without also triggering the pop func on the Routable. This PR takes an alternative approach to solving it by specifying a disablePopAction bool on the SetRouteAction. This means the pop() isn't called but the routable is removed from the array. Seems to work well from testing on a real Apple Watch.