### PR TITLE
Update to compile against the latest ReSwift and Xcode stable versions

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "ReSwift/ReSwift" ~> 5.0.0
+github "ReSwift/ReSwift" ~> 6.1.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
-github "Quick/Nimble" "v8.0.2"
-github "Quick/Quick" "v2.1.0"
-github "ReSwift/ReSwift" "5.0.0"
+github "Quick/Nimble" "v9.2.0"
+github "Quick/Quick" "v4.0.0"
+github "ReSwift/ReSwift" "6.1.0"

--- a/Package.swift
+++ b/Package.swift
@@ -5,18 +5,18 @@ import PackageDescription
 let package = Package(
     name: "ReSwift-Router",
     products: [
-      .library(name: "ReSwift-Router", targets: ["ReSwiftRouter"]),
+        .library(name: "ReSwift-Router", targets: ["ReSwiftRouter"]),
     ],
     dependencies: [
-      .package(url: "https://github.com/ReSwift/ReSwift.git", .upToNextMajor(from: "5.0.0"))
+        .package(url: "https://github.com/ReSwift/ReSwift.git", .upToNextMajor(from: "6.1.0")),
     ],
     targets: [
-      .target(
-        name: "ReSwiftRouter",
-        dependencies: [
-          "ReSwift"
-        ],
-        path: "ReSwiftRouter"
-      )
+        .target(
+            name: "ReSwiftRouter",
+            dependencies: [
+                "ReSwift"
+            ],
+            path: "ReSwiftRouter"
+        ),
     ]
 )

--- a/ReSwiftRouter.podspec
+++ b/ReSwiftRouter.podspec
@@ -18,5 +18,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.source_files     = 'ReSwiftRouter/**/*.swift'
   s.swift_versions   = [ "5.0", "4.2" ]
-  s.dependency 'ReSwift', '~> 5.0.0'
+  s.dependency 'ReSwift', '~> 6.1.0'
 end

--- a/ReSwiftRouter/Router.swift
+++ b/ReSwiftRouter/Router.swift
@@ -9,7 +9,7 @@
 import Foundation
 import ReSwift
 
-open class Router<State: StateType>: StoreSubscriber {
+open class Router<State>: StoreSubscriber {
 
     public typealias NavigationStateTransform = (Subscription<State>) -> Subscription<NavigationState>
 

--- a/ReSwiftRouterTests/ReSwiftRouterIntegrationTests.swift
+++ b/ReSwiftRouterTests/ReSwiftRouterIntegrationTests.swift
@@ -9,6 +9,7 @@
 import Quick
 import Nimble
 import ReSwift
+import Dispatch
 @testable import ReSwiftRouter
 
 class MockRoutable: Routable {
@@ -61,7 +62,7 @@ class MockRoutable: Routable {
 
 }
 
-struct FakeAppState: StateType {
+struct FakeAppState {
     var navigationState = NavigationState()
 }
 
@@ -132,7 +133,7 @@ class SwiftFlowRouterIntegrationTests: QuickSpec {
 
                     }
 
-                    waitUntil(timeout: 2.0) { fullfill in
+                    waitUntil(timeout: .seconds(2)) { fullfill in
                         let rootRoutable = FakeRootRoutable { element in
                             if element == "TabBarViewController" {
                                 fullfill()
@@ -167,7 +168,7 @@ class SwiftFlowRouterIntegrationTests: QuickSpec {
                         }
                     }
 
-                    waitUntil(timeout: 5.0) { completion in
+                    waitUntil(timeout: .seconds(5)) { completion in
                         let fakeChildRoutable = FakeChildRoutable() { element in
                             if element == "SecondViewController" {
                                 completion()

--- a/ReSwiftRouterTests/ReSwiftRouterTestsUnitTests.swift
+++ b/ReSwiftRouterTests/ReSwiftRouterTestsUnitTests.swift
@@ -15,7 +15,7 @@ import ReSwift
 class ReSwiftRouterUnitTests: QuickSpec {
 
     // Used as test app state
-    struct AppState: StateType {}
+    struct AppState {}
 
     override func spec() {
         describe("routing calls") {


### PR DESCRIPTION
Would like to use this in a project.

* Updated ReSwift to 6.1.0
* Fix compile errors/warnings under XC 12.5
* Tests passed locally