### PR TITLE
Tweak SPM module name to match README

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,9 +3,9 @@
 import PackageDescription
 
 let package = Package(
-    name: "ReSwift-Router",
+    name: "ReSwiftRouter",
     products: [
-        .library(name: "ReSwift-Router", targets: ["ReSwiftRouter"]),
+        .library(name: "ReSwiftRouter", targets: ["ReSwiftRouter"]),
     ],
     dependencies: [
         .package(url: "https://github.com/ReSwift/ReSwift.git", .upToNextMajor(from: "6.1.0")),


### PR DESCRIPTION
Tweaking the SPM from `ReSwift-Router` -> `ReSwiftRouter` to match what is in the README.

Also, Xcode doesn't seem to like the `-` in the module name.